### PR TITLE
Break out of the lookup loop after the first value found in priority mode

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -54,6 +54,7 @@ class Hiera
                 else
                     debug("Assigning answer variable")
                     answer = Backend.parse_answer(data[key], scope)
+                    break
                 end
 
             end


### PR DESCRIPTION
The backend needs to break out of it's processing loop after it finds the first value.
