### PR TITLE
Make hiera-gpg compatible with Hiera 1.0.0

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -19,7 +19,7 @@ class Hiera
         def lookup(key, scope, order_override, resolution_type)
 
             debug("Lookup called, key #{key} resolution type is #{resolution_type}")
-            answer = Backend.empty_answer(resolution_type)
+            answer = nil
 
             # This should compute ~ on both *nix and *doze
             homes = ["HOME", "HOMEPATH"]
@@ -52,9 +52,13 @@ class Hiera
                     case resolution_type
                     when :array
                         debug("Appending answer array")
+                        raise Exception, "Hiera type mismatch: expected Array and got #{parsed_answer.class}" unless parsed_answer.kind_of? Array or parsed_answer.kind_of? String
+                        answer ||= []
                         answer << parsed_answer
                     when :hash
                         debug("Merging answer hash")
+                        raise Exception, "Hiera type mismatch: expected Hash and got #{parsed_answer.class}" unless parsed_answer.kind_of? Hash
+                        answer ||= {}
                         answer = parsed_answer.merge answer
                     else
                         debug("Assigning answer variable")


### PR DESCRIPTION
Trying to use HEAD with the latest hiera releases results in:

```
$ hiera -c /etc/puppet/hiera.yaml p_storeconfigs_dbpassword
/usr/lib/ruby/site_ruby/1.8/hiera/backend/gpg_backend.rb:22:in `lookup': undefined method `empty_answer' for Hiera::Backend:Module (NoMethodError)
    from /usr/lib/ruby/site_ruby/1.8/hiera/backend.rb:159:in `lookup'
    from /usr/lib/ruby/site_ruby/1.8/hiera/backend.rb:156:in `each'
    from /usr/lib/ruby/site_ruby/1.8/hiera/backend.rb:156:in `lookup'
    from /usr/lib/ruby/site_ruby/1.8/hiera.rb:66:in `lookup'
    from /usr/bin/hiera:212
```

Specifically, empty_answer was removed from backend.rb in this merge:
https://github.com/puppetlabs/hiera/commit/f4411514847a13621c142b902cea2d8ed7197391

This pull request implements the modification which was made to yaml_backend.rb in that same merge (with some extra exception handling also present in that file).
