### PR TITLE
Do not call removed method, return nil

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -19,7 +19,7 @@ class Hiera
         def lookup(key, scope, order_override, resolution_type)
 
             debug("Lookup called, key #{key} resolution type is #{resolution_type}")
-            answer = Backend.empty_answer(resolution_type)
+            answer = nil
 
             # This should compute ~ on both *nix and *doze
             homes = ["HOME", "HOMEPATH"]


### PR DESCRIPTION
Backend.empty_answer does not exist anymore in hiera-1.0.0
For empty answer, nil should be returned.
