### PR TITLE
Allow %{} Hiera vars in hiera-gpg config params

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -27,7 +27,7 @@ class Hiera
 
             ## key_dir is the location of our GPG private keys
             ## default: ~/.gnupg
-            key_dir = Config[:gpg][:key_dir] || "#{ENV[real_home]}/.gnupg"
+            key_dir = Backend.parse_string(Config[:gpg][:key_dir], scope) || "#{ENV[real_home]}/.gnupg"
 
 
             Backend.datasources(scope, order_override) do |source|


### PR DESCRIPTION
Cf. pull request https://github.com/crayfishx/hiera-gpg/pull/12

Added code to allow %{} Hiera vars in hiera-gpg config params... just like the rest of the hiera.yaml file.

Uses Backend.parse_string
