### PR TITLE
Fix Puppet queries when no usable keys are available

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -104,6 +104,7 @@ class Hiera
                         return result
                     else
                         warn("No usable keys found in #{gnupghome}. Check :key_dir value in hiera.yaml is correct")
+                        nil
                     end
                 end
             end


### PR DESCRIPTION
The old behavior resulted in a call to `empty?` on a `Puppet::Util::Log` instance at https://github.com/crayfishx/hiera-gpg/blob/master/lib/hiera/backend/gpg_backend.rb#L38 when queried from puppet. This would throw a `MethodNotFound` exception, causing catalog compilation to fail completely rather than the expected result of a fallback to other hiera backends.
