### PR TITLE
Apply some standard Ruby style conventions

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -12,7 +12,7 @@ class Hiera
       end
 
       def warn (msg)
-        Hiera.warn("[gpg_backend]:  #{msg}")
+        Hiera.warn("[gpg_backend]: #{msg}")
       end
 
 

--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -4,7 +4,7 @@ class Hiera
 
       def initialize
         require 'gpgme'
-        debug ("Loaded gpg_backend")
+        debug("Loaded gpg_backend")
       end
 
       def debug (msg)
@@ -41,10 +41,10 @@ class Hiera
           data = YAML.load(plain)
           next if !data
           next if data.empty?
-          debug ("Data contains valid YAML")
+          debug("Data contains valid YAML")
 
           next unless data.include?(key)
-          debug ("Key #{key} found in YAML document, Passing answer to hiera")
+          debug("Key #{key} found in YAML document, Passing answer to hiera")
 
           parsed_answer = Backend.parse_answer(data[key], scope)
 

--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -1,114 +1,112 @@
 class Hiera
-    module Backend
-        class Gpg_backend
+  module Backend
+    class Gpg_backend
 
-        def initialize 
-            require 'gpgme'
-            debug ("Loaded gpg_backend")
-        end
+      def initialize
+        require 'gpgme'
+        debug ("Loaded gpg_backend")
+      end
 
-        def debug (msg)
-            Hiera.debug("[gpg_backend]: #{msg}")
-        end
+      def debug (msg)
+        Hiera.debug("[gpg_backend]: #{msg}")
+      end
 
-        def warn (msg)
-            Hiera.warn("[gpg_backend]:  #{msg}")
-        end
-
-
-        def lookup(key, scope, order_override, resolution_type)
-
-            debug("Lookup called, key #{key} resolution type is #{resolution_type}")
-            answer = nil
-
-            # This should compute ~ on both *nix and *doze
-            homes = ["HOME", "HOMEPATH"]
-            real_home = homes.detect { |h| ENV[h] != nil }
-
-            ## key_dir is the location of our GPG private keys
-            ## default: ~/.gnupg
-            key_dir = Backend.parse_string(Config[:gpg][:key_dir], scope) || "#{ENV[real_home]}/.gnupg"
+      def warn (msg)
+        Hiera.warn("[gpg_backend]:  #{msg}")
+      end
 
 
-            Backend.datasources(scope, order_override) do |source|
-                gpgfile = Backend.datafile(:gpg, scope, source, "gpg") || next
+      def lookup(key, scope, order_override, resolution_type)
 
-                plain = decrypt(gpgfile, key_dir)
-                next if !plain
-                next if plain.empty?
-                debug("GPG decrypt returned valid data")
+        debug("Lookup called, key #{key} resolution type is #{resolution_type}")
+        answer = nil
 
-                data = YAML.load(plain)
-                next if !data
-                next if data.empty?
-                debug ("Data contains valid YAML")
+        # This should compute ~ on both *nix and *doze
+        homes = ["HOME", "HOMEPATH"]
+        real_home = homes.detect { |h| ENV[h] != nil }
 
-                next unless data.include?(key)
-                debug ("Key #{key} found in YAML document, Passing answer to hiera")
+        ## key_dir is the location of our GPG private keys
+        ## default: ~/.gnupg
+        key_dir = Backend.parse_string(Config[:gpg][:key_dir], scope) || "#{ENV[real_home]}/.gnupg"
 
-                parsed_answer = Backend.parse_answer(data[key], scope)
 
-                begin
-                    case resolution_type
-                    when :array
-                        debug("Appending answer array")
-                        raise Exception, "Hiera type mismatch: expected Array and got #{parsed_answer.class}" unless parsed_answer.kind_of? Array or parsed_answer.kind_of? String
-                        answer ||= []
-                        answer << parsed_answer
-                    when :hash
-                        debug("Merging answer hash")
-                        raise Exception, "Hiera type mismatch: expected Hash and got #{parsed_answer.class}" unless parsed_answer.kind_of? Hash
-                        answer ||= {}
-                        answer = parsed_answer.merge answer
-                    else
-                        debug("Assigning answer variable")
-                        answer = parsed_answer
-                        break
-                    end
-                rescue NoMethodError
-                    raise Exception, "Resolution type is #{resolution_type} but parsed_answer is a #{parsed_answer.class}"
-                end
+        Backend.datasources(scope, order_override) do |source|
+          gpgfile = Backend.datafile(:gpg, scope, source, "gpg") || next
 
+          plain = decrypt(gpgfile, key_dir)
+          next if !plain
+          next if plain.empty?
+          debug("GPG decrypt returned valid data")
+
+          data = YAML.load(plain)
+          next if !data
+          next if data.empty?
+          debug ("Data contains valid YAML")
+
+          next unless data.include?(key)
+          debug ("Key #{key} found in YAML document, Passing answer to hiera")
+
+          parsed_answer = Backend.parse_answer(data[key], scope)
+
+          begin
+            case resolution_type
+            when :array
+              debug("Appending answer array")
+              raise Exception, "Hiera type mismatch: expected Array and got #{parsed_answer.class}" unless parsed_answer.kind_of? Array or parsed_answer.kind_of? String
+              answer ||= []
+              answer << parsed_answer
+            when :hash
+              debug("Merging answer hash")
+              raise Exception, "Hiera type mismatch: expected Hash and got #{parsed_answer.class}" unless parsed_answer.kind_of? Hash
+              answer ||= {}
+              answer = parsed_answer.merge answer
+            else
+              debug("Assigning answer variable")
+              answer = parsed_answer
+              break
             end
-            return answer
+          rescue NoMethodError
+            raise Exception, "Resolution type is #{resolution_type} but parsed_answer is a #{parsed_answer.class}"
+          end
+
         end
+        return answer
+      end
 
-        def decrypt(file, gnupghome)
+      def decrypt(file, gnupghome)
 
-            ENV["GNUPGHOME"]=gnupghome
-            debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
+        ENV["GNUPGHOME"]=gnupghome
+        debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
 
-            ctx = GPGME::Ctx.new
+        ctx = GPGME::Ctx.new
 
-            open(file) do |cipher|
-                debug("loaded cipher: #{file}")
+        open(file) do |cipher|
+          debug("loaded cipher: #{file}")
 
-                ctx = GPGME::Ctx.new
+          ctx = GPGME::Ctx.new
 
-                    if !ctx.keys.empty?
-                        raw = GPGME::Data.new(cipher)
-                        txt = GPGME::Data.new
+          if !ctx.keys.empty?
+            raw = GPGME::Data.new(cipher)
+            txt = GPGME::Data.new
 
-                        begin
-                            txt = ctx.decrypt(raw)
-                        rescue GPGME::Error::DecryptFailed
-                            warn("Warning: GPG Decryption failed, check your GPG settings")
-                        rescue
-                            warn("Warning: General exception decrypting GPG file")
-                        end
-                        
-                        txt.seek 0
-                        result = txt.read
-
-                        debug("result is a #{result.class} ctx #{ctx} txt #{txt}")
-                        return result
-                    else
-                        warn("No usable keys found in #{gnupghome}. Check :key_dir value in hiera.yaml is correct")
-                    end
-                end
+            begin
+              txt = ctx.decrypt(raw)
+            rescue GPGME::Error::DecryptFailed
+              warn("Warning: GPG Decryption failed, check your GPG settings")
+            rescue
+              warn("Warning: General exception decrypting GPG file")
             end
+
+            txt.seek 0
+            result = txt.read
+
+            debug("result is a #{result.class} ctx #{ctx} txt #{txt}")
+            return result
+          else
+            warn("No usable keys found in #{gnupghome}. Check :key_dir value in hiera.yaml is correct")
+          end
         end
+      end
     end
+  end
 end
-
-

--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -17,7 +17,6 @@ class Hiera
 
 
       def lookup(key, scope, order_override, resolution_type)
-
         debug("Lookup called, key #{key} resolution type is #{resolution_type}")
         answer = nil
 
@@ -28,7 +27,6 @@ class Hiera
         ## key_dir is the location of our GPG private keys
         ## default: ~/.gnupg
         key_dir = Backend.parse_string(Config[:gpg][:key_dir], scope) || "#{ENV[real_home]}/.gnupg"
-
 
         Backend.datasources(scope, order_override) do |source|
           gpgfile = Backend.datafile(:gpg, scope, source, "gpg") || next

--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -72,8 +72,7 @@ class Hiera
       end
 
       def decrypt(file, gnupghome)
-
-        ENV["GNUPGHOME"]=gnupghome
+        ENV["GNUPGHOME"] = gnupghome
         debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
 
         ctx = GPGME::Ctx.new


### PR DESCRIPTION
Let me preface this: I normally hate whitespace commits/pull requests.
However, there are some broadly accepted Ruby style conventions that I
think are valuable to follow, if only to make it easier for other Ruby
devs to contribute. Please feel free to disregard this PR if you don't
agree :wink:

Doing a `git diff --ignore-space-change` lists only a few actual lines
of diff, from revs c4e31fe and e8146db. The main whitespace change is
2-space soft tab indentation, which hides those two real changes since
every line has been touched.
