### PR TITLE
Fix when using key_dir config

### DIFF
--- a/lib/hiera/backend/gpg_backend.rb
+++ b/lib/hiera/backend/gpg_backend.rb
@@ -75,7 +75,12 @@ class Hiera
 
         def decrypt(file, gnupghome)
 
-            ENV["GNUPGHOME"]=gnupghome
+            if gnupghome.kind_of?(Array)
+                ENV["GNUPGHOME"]=gnupghome[0]
+            else
+                ENV["GNUPGHOME"]=gnupghome
+            end
+            
             debug("GNUPGHOME is #{ENV['GNUPGHOME']}")
 
             ctx = GPGME::Ctx.new


### PR DESCRIPTION
When key_dir setting is used in gpg hiera section, an exception is thrown because what is supposed to be a string is an array instead. Type check added
